### PR TITLE
Revert "Change format"

### DIFF
--- a/deploy/crds/postgresql_v1alpha1_database_crd.yaml
+++ b/deploy/crds/postgresql_v1alpha1_database_crd.yaml
@@ -4,16 +4,16 @@ metadata:
   name: databases.postgresql.baiju.dev
   annotations:
     servicebindingoperator.redhat.io/spec.dbName: 'binding:env:attribute'
-    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.host'
-    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.name'
-    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.password'
-    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.port'
-    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.user'
+    servicebindingoperator.redhat.io/status.dbCredentials.user: 'binding:env:object:secret'
+    servicebindingoperator.redhat.io/status.dbCredentials.password: 'binding:env:object:secret'
     servicebindingoperator.redhat.io/status.dbConnectionIP: 'binding:env:attribute'
     servicebindingoperator.redhat.io/status.dbConnectionPort: 'binding:env:attribute'
-    servicebindingoperator.redhat.io/status.dbCredentials: 'binding:env:object:secret:password'
-    servicebindingoperator.redhat.io/status.dbCredentials: 'binding:env:object:secret:user'
     servicebindingoperator.redhat.io/status.dbName: 'binding:env:attribute'
+    servicebindingoperator.redhat.io/status.dbConfigMap.db.host: 'binding:env:object:configmap'
+    servicebindingoperator.redhat.io/status.dbConfigMap.db.port: 'binding:env:object:configmap'
+    servicebindingoperator.redhat.io/status.dbConfigMap.db.name: 'binding:env:object:configmap'
+    servicebindingoperator.redhat.io/status.dbConfigMap.db.user: 'binding:env:object:configmap'
+    servicebindingoperator.redhat.io/status.dbConfigMap.db.password: 'binding:env:object:configmap'
 spec:
   group: postgresql.baiju.dev
   names:


### PR DESCRIPTION
Reverts operator-backing-service-samples/postgresql-operator#4

The `annotations` part of the CRD yaml is not valid - there are duplicate keys, which may cause that all but one will be ignored:

```yaml
  annotations:
    servicebindingoperator.redhat.io/spec.dbName: 'binding:env:attribute'
    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.host'
    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.name'
    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.password'
    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.port'
    servicebindingoperator.redhat.io/status.dbConfigMap: 'binding:env:object:configmap:db.user'
    servicebindingoperator.redhat.io/status.dbConnectionIP: 'binding:env:attribute'
    servicebindingoperator.redhat.io/status.dbConnectionPort: 'binding:env:attribute'
    servicebindingoperator.redhat.io/status.dbCredentials: 'binding:env:object:secret:password'
    servicebindingoperator.redhat.io/status.dbCredentials: 'binding:env:object:secret:user'
    servicebindingoperator.redhat.io/status.dbName: 'binding:env:attribute'
```