### PR TITLE
Update CRD with operator-sdk 0.19.4

### DIFF
--- a/deploy/crds/postgresql_v1alpha1_database_crd.yaml
+++ b/deploy/crds/postgresql_v1alpha1_database_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: databases.postgresql.baiju.dev
@@ -23,25 +23,67 @@ spec:
     shortNames:
       - db
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          type: object
-        status:
-          type: object
-  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Database is the Schema for the databases API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DatabaseSpec defines the desired state of Database
+            properties:
+              dbName:
+                type: string
+              image:
+                description: Location of the PostgreSQL container image. e.g., docker.io/postgres
+                type: string
+              imageName:
+                description: Name of the PostgreSQL container image. e.g., postgres
+                type: string
+            required:
+            - dbName
+            - image
+            - imageName
+            type: object
+          status:
+            description: DatabaseStatus defines the observed state of Database
+            properties:
+              dbConfigMap:
+                type: string
+              dbConnectionIP:
+                type: string
+              dbConnectionPort:
+                format: int64
+                type: integer
+              dbCredentials:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+                type: string
+              dbName:
+                type: string
+            required:
+            - dbConfigMap
+            - dbConnectionIP
+            - dbConnectionPort
+            - dbCredentials
+            - dbName
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
```
$ operator-sdk version
operator-sdk version: "v0.19.4", commit: "125d0dfcc71fef4f9d7e2a42b1354cb79ffdee03", kubernetes version: "v1.18.2", go version: "go1.13.15 linux/amd64"

$ operator-sdk generate crds
```
- apiVersion from v1beta1 to v1 (v1beta1 has been removed from v1.22 Kubernetes API)
- added details of spec and status (spec is useful for odo to build parameters list: https://github.com/openshift/odo/issues/4850)
